### PR TITLE
Extend access copy worker to linked resources and refactor access permissions copying

### DIFF
--- a/app/repository_models/curation_concern/work.rb
+++ b/app/repository_models/curation_concern/work.rb
@@ -18,5 +18,25 @@ module CurationConcern
       return solr_doc
     end
 
+    def synchronize_link_and_file_permissions
+      assets = self.attached_files_and_links
+      unless assets.nil?
+        assets.each do |asset|
+          asset.edit_users = self.edit_users
+          asset.edit_groups = self.edit_groups
+          asset.save!
+        end
+      end
+    end
+
+    def attached_files_and_links
+      files = self.generic_files
+      links = self.linked_resources
+      return nil if files.blank? and links.blank?
+      return links if files.nil? 
+      return files if links.nil? 
+      files + links
+    end
+
   end
 end

--- a/app/workers/access_permissions_copy_worker.rb
+++ b/app/workers/access_permissions_copy_worker.rb
@@ -19,12 +19,6 @@ class AccessPermissionsCopyWorker
 
   def run
     work = ActiveFedora::Base.find(pid, cast: true)
-    if work.respond_to?(:generic_files)
-      work.generic_files.each do |file|
-        file.edit_users = work.edit_users
-        file.edit_groups = work.edit_groups
-        file.save!
-      end    
-    end
+    work.synchronize_link_and_file_permissions
   end
 end

--- a/app/workers/delegate_editor_assign_worker.rb
+++ b/app/workers/delegate_editor_assign_worker.rb
@@ -36,13 +36,7 @@ class DelegateEditorAssignWorker
         grantee.work_ids += [work.pid]
         grantee.save!
 
-        if work.respond_to?(:generic_files)
-	        work.generic_files.each do |file|
-            file.edit_users = work.edit_users
-            file.edit_groups = work.edit_groups
-            file.save!
-          end    
-        end
+        work.synchronize_link_and_file_permissions
       end
     end
   end

--- a/app/workers/delegate_editor_cleanup_worker.rb
+++ b/app/workers/delegate_editor_cleanup_worker.rb
@@ -31,22 +31,16 @@ class DelegateEditorCleanupWorker
     type.each do |klass|
       klass.find_each('edit_access_person_ssim' => grantee.email) do |work|
         next unless work.owner != grantee.email
-          work.edit_users -= [grantee.email]
-          work.editor_ids += [grantor.pid]
-          work.editor_ids -= [grantee.pid]
-          work.save!
+        work.edit_users -= [grantee.email]
+        work.editor_ids += [grantor.pid]
+        work.editor_ids -= [grantee.pid]
+        work.save!
 
-          grantee.work_ids -= [work.pid]
-          grantee.save!
+        grantee.work_ids -= [work.pid]
+        grantee.save!
 
-          if work.respond_to?(:generic_files)
-	          work.generic_files.each do |file|
-              file.edit_users = work.edit_users
-              file.edit_groups = work.edit_groups
-              file.save!
-            end
-          end    
-        end
+        work.synchronize_link_and_file_permissions
       end
     end
   end
+end

--- a/spec/repository_models/curation_concern/work_spec.rb
+++ b/spec/repository_models/curation_concern/work_spec.rb
@@ -6,4 +6,81 @@ describe CurationConcern::Work do
       expect(described_class.ids_from_tokens("ab , cd ")).to eq(['ab', 'cd'])
     end
   end
+
+  describe "#attached_files_and_links" do
+    let(:work) { FactoryGirl.create(:generic_work) }
+
+    context 'links and files' do
+      before { work.stub(:generic_files) { ['file', 'file'] } }
+      before { work.stub(:linked_resources) { ['link'] } }
+
+      it 'returns array with links and files' do
+        expect(work.attached_files_and_links.class).to eq(Array)
+        expect(work.attached_files_and_links.length).to eq(3)
+      end
+    end
+
+    context 'links, no files' do
+      before { work.stub(:linked_resources) { ['link'] } }
+
+      it 'returns array with only links' do
+        expect(work.attached_files_and_links.class).to eq(Array)
+        expect(work.attached_files_and_links.length).to eq(1)
+      end
+    end
+ 
+    context 'files, no links' do
+      before { work.stub(:generic_files) { ['file', 'file'] } }
+
+      it 'returns array with only files' do
+        expect(work.attached_files_and_links.class).to eq(Array)
+        expect(work.attached_files_and_links.length).to eq(2)
+      end
+    end
+
+    context 'no links or files' do
+      it 'returns nil' do
+        puts work.generic_files
+        expect(work.attached_files_and_links).to eq(nil)
+      end
+    end
+  end
+
+  describe '#synchronize_link_and_file_permissions' do
+    let(:work) { FactoryGirl.create(:generic_work_with_files) }
+
+    it 'adds and removes additional edit users to attached assets' do
+      expect(work.generic_files.first.edit_users.length).to eq(1)
+      work.edit_users += ["foo"]
+      work.save
+      work.reload
+
+      work.synchronize_link_and_file_permissions
+      expect(work.generic_files.first.edit_users.length).to eq(2)
+
+      work.edit_users -= ["foo"]
+      work.save
+      work.reload
+
+      work.synchronize_link_and_file_permissions
+      expect(work.generic_files.first.edit_users.length).to eq(1)
+    end
+
+    it 'adds and removes additional edit groups to attached assets' do
+      expect(work.generic_files.first.edit_groups.length).to eq(0)
+      work.edit_groups += ["foo"]
+      work.save
+      work.reload
+
+      work.synchronize_link_and_file_permissions
+      expect(work.generic_files.first.edit_groups.length).to eq(1)
+
+      work.edit_groups -= ["foo"]
+      work.save
+      work.reload
+
+      work.synchronize_link_and_file_permissions
+      expect(work.generic_files.first.edit_groups.length).to eq(0)
+    end
+  end
 end


### PR DESCRIPTION
I was duplicating a lot of logic within workers to fix the problem with delegates retaining permission to external links, so I moved that logic into the models.

Closes https://github.com/uclibs/scholar_uc/issues/575
