### PR TITLE
Sort collection items by title

### DIFF
--- a/app/helpers/curate/collections_helper.rb
+++ b/app/helpers/curate/collections_helper.rb
@@ -38,7 +38,7 @@ module Curate::CollectionsHelper
   #     When set to false, the creators are not listed.
   def list_items_in_collection(collection, terminate=false, options={})
     content_tag :ul, class: 'collection-listing' do
-      collection.members.inject('') do |output, member|
+      (collection.members.sort_by { |member| member.sortable_title }).inject('') do |output, member|
         output << member_line_item(collection, member, terminate, options)
       end.html_safe
     end

--- a/app/repository_models/curation_concern/model.rb
+++ b/app/repository_models/curation_concern/model.rb
@@ -49,6 +49,10 @@ module CurationConcern
       collection == self ? false : true
     end
 
+    def sortable_title
+      title.sub(/^(the|a|an)\s+/i, '')
+    end
+
 protected
 
     # A searchable date field that is derived from the (text) field date_created

--- a/spec/repository_models/curation_concern/model_spec.rb
+++ b/spec/repository_models/curation_concern/model_spec.rb
@@ -22,4 +22,12 @@ describe CurationConcern::Model do
       reloaded_work.to_solr["collection_sim"].should_not == [profile.pid]
     end
   end
+
+  describe '#sortable_title' do
+    let(:work) { FactoryGirl.create(:generic_work, title: "A title") }
+
+    it 'filters articles from the beginning of titles' do
+      expect(work.sortable_title).to eq("title")
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/uclibs/scholar_uc/issues/550

Depending on a regular expression buried inside a model probably isn't the best solution, but it works.

I intentionally went light on the testing - testing whether the output is sorted in the view is essentially the same as testing whether the sort_by function works - this is tested elsewhere and doesn't provide any value in our suite, IMO.

Also, I only tested one case of the sortable_title function I introduced - I think adding more filtered articles would slow down the test suite more than is worthwhile.

Differing opinions are welcome!
