### PR TITLE
Display timestamp of last deploy when applicable

### DIFF
--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -6,7 +6,7 @@
         Made possible by the <a href="http://projecthydra.org">Hydra</a> project.
       </p>
       <p>
-        Build: <%= Curate.configuration.build_identifier %>
+        <%= Curate.configuration.build_identifier %>
       </p>
     </div>
   </div>

--- a/lib/curate/configuration.rb
+++ b/lib/curate/configuration.rb
@@ -38,7 +38,11 @@ module Curate
       # If you restart the server, this could be out of sync; A better
       # implementation is to read something from the file system. However
       # that detail is an exercise for the developer.
-      @build_identifier ||= Time.now.strftime("%Y-%m-%d %H:%M:%S")
+      if File.file?('config/deploy_timestamp')
+        @build_identifier = "Deployed on " + File.open('config/deploy_timestamp', &:readline)
+      else
+        @build_identifier ||= "Started on " + Time.now.strftime("%m-%d-%Y %r")
+      end
     end
 
     # Override characterization runner


### PR DESCRIPTION
When Scholar is deployed to the dev/QA/production servers, Bamboo will create a config/deploy_timestamp file that contains the date and time of the deploy.  This commit puts that timestamp into the page footer.  If the deploy_timestamp file is not available, the date when the application was last restarted is used (e.g. Larry and our local environments).

I did not include the version tag in the footer because it presents some possibly confusing and inaccurate scenarios.  I'll discuss that at our next standup.
