### PR TITLE
fixes whitespace in metadata

### DIFF
--- a/app/assets/javascripts/required_form_validate.js
+++ b/app/assets/javascripts/required_form_validate.js
@@ -1,5 +1,5 @@
 /*
-This file is to fix #588, adds validations to any input field within form with the class of 'no-space'.
+This file is to fix #588, adds validations to any input field within form with the class of 'validate-me'.
 
 you can add the class to any new work form in the _form_required_information template
 
@@ -15,9 +15,13 @@ function isValid(requiredField) {
  	}
 }
 
+function stripWhiteSpace(requiredField) {
+	requiredField.replace('\v', ' ')
+}
+
 function validateAllFields() {
-	//collect all elements with the class 'no-space' into array
-	var inputs = document.getElementsByClassName('no-space');
+	//collect all elements with the class 'validate-me' into array
+	var inputs = document.getElementsByClassName('validate-me');
 	var valid = true;
 	//cycle through and validate all of the input values, not the elements themselves.
 	for (var i = 0; i < inputs.length; i+=1) {
@@ -27,6 +31,7 @@ function validateAllFields() {
 			valid = false;
 			break;
 		}
+		stripWhiteSpace(inputs[i].value);
 	}
 	if (valid) {
 		document.forms['new_work_form'].submit();

--- a/app/assets/stylesheets/modules/forms.css.scss
+++ b/app/assets/stylesheets/modules/forms.css.scss
@@ -3,6 +3,11 @@
   width:100%;
 }
 
+.full-width {
+  width: 100%;
+
+}
+
 legend small {
   margin-left:.5em;
 }

--- a/app/views/curation_concern/articles/_form_required_information.html.erb
+++ b/app/views/curation_concern/articles/_form_required_information.html.erb
@@ -11,8 +11,8 @@
       <div class="row">
           <div class="span6">
             <%= f.input :title, 
-                        as: :text,
-                        input_html: { class: 'input-xxxlarge no-space', rows: '1' } %>
+                        as: :string,
+                        input_html: { class: 'validate-me full-width', rows: '1' } %>
           </div>
           <%= render 'form_input_help_block', help_text: I18n.t('sufia.work.input_field.title.help', work_type: curation_concern.human_readable_type) %>
       </div>
@@ -32,7 +32,7 @@
           <%= f.input :abstract, 
                       as: :text, 
                       required: true, 
-                      input_html: { class: 'input-xxxlarge no-space', rows: '14' } %>
+                      input_html: { class: 'input-xxxlarge validate-me', rows: '14' } %>
         </div>
         <%= render 'form_input_help_block', help_text: I18n.t('sufia.work.input_field.abstract.help', work_type: curation_concern.human_readable_type) %>
       </div>

--- a/app/views/curation_concern/datasets/_form_required_information.html.erb
+++ b/app/views/curation_concern/datasets/_form_required_information.html.erb
@@ -11,8 +11,8 @@
       <div class="row">
           <div class="span6">
             <%= f.input :title, 
-                        as: :text,
-                        input_html: { class: 'input-xxxlarge no-space', rows: '1' } %>
+                        as: :string,
+                        input_html: { class: 'validate-me full-width', rows: '1' } %>
           </div>
           <%= render 'form_input_help_block', help_text: I18n.t('sufia.work.input_field.title.help', work_type: curation_concern.human_readable_type) %>
       </div>
@@ -31,7 +31,7 @@
           <%= f.input :description, 
                       as: :text, 
                       required: true, 
-                      input_html: { class: 'input-xxxlarge no-space', rows: '14' } %>
+                      input_html: { class: 'input-xxxlarge validate-me', rows: '14' } %>
         </div>
         <%= render 'form_input_help_block', help_text: I18n.t('sufia.work.input_field.description.help', work_type: curation_concern.human_readable_type) %>
       </div>

--- a/app/views/curation_concern/documents/_form_required_information.html.erb
+++ b/app/views/curation_concern/documents/_form_required_information.html.erb
@@ -11,8 +11,8 @@
       <div class="row">
           <div class="span6">
             <%= f.input :title, 
-                        as: :text,
-                        input_html: { class: 'input-xxxlarge no-space', rows: '1' } %>
+                        as: :string,
+                        input_html: { class: 'validate-me full-width', rows: '1' } %>
           </div>
           <%= render 'form_input_help_block', help_text: I18n.t('sufia.work.input_field.title.help', work_type: curation_concern.human_readable_type) %>
       </div>
@@ -31,7 +31,7 @@
           <%= f.input :description, 
                       as: :text, 
                       required: true, 
-                      input_html: { class: 'input-xxxlarge no-space', rows: '14' } %>
+                      input_html: { class: 'input-xxxlarge validate-me', rows: '14' } %>
         </div>
         <%= render 'form_input_help_block', help_text: I18n.t('sufia.work.input_field.description.help', work_type: curation_concern.human_readable_type) %>
       </div>

--- a/app/views/curation_concern/generic_works/_form_required_information.html.erb
+++ b/app/views/curation_concern/generic_works/_form_required_information.html.erb
@@ -11,8 +11,8 @@
       <div class="row">
           <div class="span6">
             <%= f.input :title, 
-                        as: :text,
-                        input_html: { class: 'input-xxxlarge no-space', rows: '1' } %>
+                        as: :string,
+                        input_html: { class: 'validate-me full-width', rows: '1' } %>
           </div>
           <%= render 'form_input_help_block', help_text: I18n.t('sufia.work.input_field.title.help', work_type: curation_concern.human_readable_type) %>
       </div>
@@ -32,7 +32,7 @@
           <%= f.input :description, 
                       as: :text, 
                       required: true, 
-                      input_html: { class: 'input-xxxlarge no-space', rows: '14' } %>
+                      input_html: { class: 'input-xxxlarge validate-me', rows: '14' } %>
         </div>
         <%= render 'form_input_help_block', help_text: I18n.t('sufia.work.input_field.description.help', work_type: curation_concern.human_readable_type) %>
       </div>

--- a/app/views/curation_concern/images/_form_required_information.html.erb
+++ b/app/views/curation_concern/images/_form_required_information.html.erb
@@ -11,8 +11,8 @@
       <div class="row">
           <div class="span6">
             <%= f.input :title, 
-                        as: :text,
-                        input_html: { class: 'input-xxxlarge', rows: '1' } %>
+                        as: :string,
+                        input_html: { class: 'validate-me full-width', rows: '1' } %>
           </div>
           <%= render 'form_input_help_block', help_text: I18n.t('sufia.work.input_field.title.help', work_type: curation_concern.human_readable_type) %>
       </div>
@@ -31,7 +31,7 @@
           <%= f.input :description, 
                       as: :text, 
                       required: true, 
-                      input_html: { class: 'input-xxxlarge', rows: '14' } %>
+                      input_html: { class: 'input-xxxlarge validate-me', rows: '14' } %>
         </div>
         <%= render 'form_input_help_block', help_text: I18n.t('sufia.work.input_field.description.help', work_type: curation_concern.human_readable_type) %>
       </div>

--- a/app/views/curation_concern/videos/_form_required_information.html.erb
+++ b/app/views/curation_concern/videos/_form_required_information.html.erb
@@ -11,8 +11,8 @@
       <div class="row">
           <div class="span6">
             <%= f.input :title, 
-                        as: :text,
-                        input_html: { class: 'input-xxxlarge', rows: '1' } %>
+                        as: :string,
+                        input_html: { class: 'validate-me full-width', rows: '1' } %>
           </div>
           <%= render 'form_input_help_block', help_text: I18n.t('sufia.work.input_field.title.help', work_type: curation_concern.human_readable_type) %>
       </div>
@@ -33,7 +33,7 @@
           <%= f.input :description, 
                       as: :text, 
                       required: true, 
-                      input_html: { class: 'input-xxxlarge', rows: '14' } %>
+                      input_html: { class: 'input-xxxlarge validate-me', rows: '14' } %>
         </div>
         <%= render 'form_input_help_block', help_text: I18n.t('sufia.work.input_field.description.help', work_type: curation_concern.human_readable_type) %>
       </div>


### PR DESCRIPTION
closes uclibs/scholar_uc#496

In lieu of complicated validators and hacking up and spitting out strings, changing the input type to text instead of textarea disallows line breaks of any kind.

before fix:
![bug_not_fixed](https://cloud.githubusercontent.com/assets/12615997/13881068/d0806322-ecf5-11e5-8732-03382e9ebe74.png)

after fix:
![bug_fixed](https://cloud.githubusercontent.com/assets/12615997/13881083/db9c4190-ecf5-11e5-993a-e9805ac2e6b3.png)
