### PR TITLE
Allow profile photos to display when profiles are not public

### DIFF
--- a/app/controllers/downloads_controller.rb
+++ b/app/controllers/downloads_controller.rb
@@ -19,7 +19,7 @@ class DownloadsController < ApplicationController
   ## Overriding Hydra::Controller::DownloadBehavior.datastream_name to return asset.filename instead of asset.label
   def datastream_name
     ## Except for objects where the files are avatars
-    unless [Person, Collection].include? asset.class 
+    unless [Person, Collection].include? asset.class
       params[:filename] || asset.filename
     end
   end
@@ -38,6 +38,10 @@ class DownloadsController < ApplicationController
   def respond_with_default_thumbnail_image
     image= ActionController::Base.helpers.asset_path("curate/default.png", type: :image)
     redirect_to image
+  end
+
+  def can_download?
+    return true if asset.is_a?(Person) || (can? :read, datastream.pid)
   end
 
 end

--- a/spec/features/person_profile_spec.rb
+++ b/spec/features/person_profile_spec.rb
@@ -117,7 +117,7 @@ describe 'Profile for a Person: ' do
     end
   end
 
-  context 'A person when logged in' do
+  context 'A person' do
     let(:password) { FactoryGirl.attributes_for(:user).fetch(:password) }
     let(:account) { FactoryGirl.create(:account, first_name: 'Iron', last_name: 'Man') }
     let(:user) { account.user }
@@ -127,11 +127,18 @@ describe 'Profile for a Person: ' do
       login_as(user)
     end
 
-    it 'should have a profile image in show view' do
+    it 'when logged in should have a profile image in show view' do
       create_image(image_file)
       visit('/')
       click_link "My Profile"
       page.should have_css("img[src$='/downloads/#{person.pid}?datastream_id=medium']")
+    end
+
+    it 'when logged out should have a public profile image' do
+      create_image(image_file)
+      logout
+      visit("/downloads/#{person.pid}?datastream_id=medium")
+      page.status_code.should be 200
     end
 
     it 'should show gravatar image if profile image not uploaded' do


### PR DESCRIPTION
An example of this bug with a broken profile image on production can be seen here:
https://scholar.uc.edu/people/05741r94m
