### PR TITLE
refactors group page

### DIFF
--- a/app/assets/stylesheets/curate/linkedUsers.css.scss
+++ b/app/assets/stylesheets/curate/linkedUsers.css.scss
@@ -1,7 +1,9 @@
+
+
 .link-users {
   .input-append .linked-user {
     display: inline-block;
-    width: 380px;
+    //width: 275px;
     height: 20px;
     padding: 4px;
     font-size: 14pt;

--- a/app/assets/stylesheets/curate/linkedUsers.css.scss
+++ b/app/assets/stylesheets/curate/linkedUsers.css.scss
@@ -1,10 +1,12 @@
 @media (min-width: 480px) and (max-width: 767px) {
+  #editors > div > ul.listing {
+    .input-append .linked-user {
+      width: 365px !important;
+    }
+  }
   .link-users { 
     .input-append input[type="text"] {
-    width: 400px !important;
-    }
-    .filled-in {
-      width: 380px !important;
+    width: 400px;
     }
     .radio input[type="radio"], .checkbox input[type="checkbox"] {
       float: none;
@@ -13,12 +15,10 @@
   }
 }
 @media (max-width: 480px) {
-
   .link-users { 
     .input-append input[type="text"] {
       width: 300px;
     }
-
     .filled-in {
       width: 280px !important;
     }
@@ -28,8 +28,6 @@
     } 
   }
 }
-
-
 .link-users {  
   .input-append .linked-user {
     display: inline-block;
@@ -39,12 +37,9 @@
     border-radius: 4px 0 0 4px;
     border: 1px solid #cccccc;
   }
-
-
   .current-user {
     border: 0px !important;
   }
-
   .listing {
     margin: 0;
   }
@@ -53,4 +48,8 @@
     overflow: hidden;
   }
 }
-
+#editors > div > ul.listing {
+  .input-append .linked-user {
+    width: 275px;
+  }
+}

--- a/app/assets/stylesheets/curate/linkedUsers.css.scss
+++ b/app/assets/stylesheets/curate/linkedUsers.css.scss
@@ -1,9 +1,38 @@
+@media (min-width: 480px) and (max-width: 767px) {
+  .link-users { 
+    .input-append input[type="text"] {
+    width: 400px !important;
+    }
+    .filled-in {
+      width: 380px !important;
+    }
+    .radio input[type="radio"], .checkbox input[type="checkbox"] {
+      float: none;
+      margin-left: 20px !important;
+    } 
+  }
+}
+@media (max-width: 480px) {
+
+  .link-users { 
+    .input-append input[type="text"] {
+      width: 300px;
+    }
+
+    .filled-in {
+      width: 280px !important;
+    }
+    .radio input[type="radio"], .checkbox input[type="checkbox"] {
+      float: none;
+      margin-left: 20px !important;
+    } 
+  }
+}
 
 
-.link-users {
+.link-users {  
   .input-append .linked-user {
     display: inline-block;
-    //width: 275px;
     height: 20px;
     padding: 4px;
     font-size: 14pt;
@@ -11,12 +40,17 @@
     border: 1px solid #cccccc;
   }
 
+
   .current-user {
     border: 0px !important;
   }
 
   .listing {
     margin: 0;
+  }
+  .filled-in {
+    width: 380px;
+    overflow: hidden;
   }
 }
 

--- a/app/views/hydramata/groups/_form.html.erb
+++ b/app/views/hydramata/groups/_form.html.erb
@@ -48,7 +48,7 @@
   </div>
 
     <div class="row">
-      <div class="span6" >
+      <div class="span10" >
         <fieldset >
           <%= render partial: 'linked_members', locals: {f: f} %>
         </fieldset>

--- a/app/views/hydramata/groups/_linked_members.html.erb
+++ b/app/views/hydramata/groups/_linked_members.html.erb
@@ -15,7 +15,6 @@
   </div>
   <div class="controls">
     <% prefix = f.object_name.downcase %>
-
     <script id="entry-template" type="text/x-handlebars-template">
       <li class="field-wrapper input-append">
         <div class="row">
@@ -28,7 +27,7 @@
               </button>
             </span>
           </div>
-          <div class="span2 offset1 ">
+          <div class="span2 offset1">
             <label class="checkbox inline-checkbox ">Can edit group<%= check_box_tag "group_member[edit_users_ids][]", false %></label>
             <input id="<%=prefix %>_members_attributes_{{index}}_id" name="<%=prefix %>[members_attributes][{{index}}][id]" type="hidden" value="" />
           </div>
@@ -56,7 +55,6 @@
         </div>
       </li>
     </script>
-
     <ul class="listing">
       <% if !@group.nil? && @group.members != [] %>
         <%= f.fields_for :members do |memberField| %>
@@ -100,4 +98,3 @@
     </ul>
   </div>
 </div>
-

--- a/app/views/hydramata/groups/_linked_members.html.erb
+++ b/app/views/hydramata/groups/_linked_members.html.erb
@@ -2,24 +2,25 @@
 <legend class="accessible-hidden">Edit Group Members</legend>
 <div class="control-group required link-users" id="members">
   <div class="row">
-    <div class="span5">
+    <div class="span7">
       <span class="control-label">
         <label class="required" for="<%=f.object_name.downcase%>_members_attributes_0_name">
           <%= label %>
         </label>
       </span>
     </div>
-    <div class="span1 text-center hidden">
-      Can edit group
+    <div class="span2 offset1 text-center hidden">
+      Can edit grouptest
     </div>
   </div>
-  <div class="controls">
+  endrow
+  <div class="controls">test
     <% prefix = f.object_name.downcase %>
 
     <script id="entry-template" type="text/x-handlebars-template">
       <li class="field-wrapper input-append">
         <div class="row">
-          <div class="span5">
+          <div class="span7">
             <input class="input-xlarge autocomplete-users" data-url="/people" id="<%=prefix %>_members_attributes_{{index}}_name" name="<%=prefix %>[members_attributes][{{index}}][name]" type="text" value="" />
             <span class="field-controls">
               <button type="button" class="btn btn-success add">
@@ -28,8 +29,8 @@
               </button>
             </span>
           </div>
-          <div class="span1 text-center">
-            <label class="checkbox inline-checkbox">Can edit group<%= check_box_tag "group_member[edit_users_ids][]", false %></label>
+          <div class="span2 offset1 text-center">
+            <label class="checkbox inline-checkbox">Can edit group - added<%= check_box_tag "group_member[edit_users_ids][]", false %></label>
             <input id="<%=prefix %>_members_attributes_{{index}}_id" name="<%=prefix %>[members_attributes][{{index}}][id]" type="hidden" value="" />
           </div>
         </div>
@@ -38,7 +39,7 @@
     <script id="existing-user-template" type="text/x-handlebars-template">
       <li class="field-wrapper input-append">
         <div class="row">
-          <div class="span5">
+          <div class="span7">
             <span class="linked-user">
               <a href="/people/{{value}}" target="_new">{{label}}</a>
             </span>
@@ -50,8 +51,8 @@
               </button>
             </span>
           </div>
-          <div class="span1 text-center">
-            <label class="checkbox inline-checkbox">Can edit group<%= check_box_tag "group_member[edit_users_ids][]", "{{value}}", @group.edit_users.include?("{{value}}") %></label>
+          <div class="span2 offset1 text-center">
+            <label class="checkbox inline-checkbox">Can edit group - filled out<%= check_box_tag "group_member[edit_users_ids][]", "{{value}}", @group.edit_users.include?("{{value}}") %></label>
           </div>
         </div>
       </li>
@@ -64,7 +65,7 @@
           <div class="row">
             <%= memberField.hidden_field :id %>
             <%= memberField.hidden_field :_destroy %>
-            <div class="span5">
+            <div class="span7">
               <% if memberField.object.persisted? %>
                 <% if ( @group.edit_users.include?(memberField.object.user_key) && @group.edit_users.size == 1 ) %>
                   <span class="linked-user current-user"><%=link_to memberField.object.name, memberField.object, target: '_new' %></span>
@@ -79,8 +80,8 @@
                 <span class="field-controls"></span>
               <% end %>
             </div>
-            <div class="span1 text-center">
-              <label class="checkbox inline-checkbox">Can edit group
+            <div class="span2 offset1 text-center">
+              <label class="checkbox inline-checkbox">Can edit group - normal
                 <% if memberField.object.persisted? %>
                   <% if ( @group.edit_users.include?(memberField.object.user_key) && ( @group.edit_users.size == 1 ) ) %>
                     <%= check_box_tag "current_user_disabled", 'checked', true, disabled: true %>
@@ -97,7 +98,7 @@
         </li>
         <% end %>
       <% end %>
-    </ul>
+    </ul>endtest
   </div>
 </div>
 

--- a/app/views/hydramata/groups/_linked_members.html.erb
+++ b/app/views/hydramata/groups/_linked_members.html.erb
@@ -9,12 +9,11 @@
         </label>
       </span>
     </div>
-    <div class="span2 offset1 text-center hidden">
-      Can edit grouptest
+    <div class="span2 offset1 hidden">
+      Can edit group
     </div>
   </div>
-  endrow
-  <div class="controls">test
+  <div class="controls">
     <% prefix = f.object_name.downcase %>
 
     <script id="entry-template" type="text/x-handlebars-template">
@@ -29,8 +28,8 @@
               </button>
             </span>
           </div>
-          <div class="span2 offset1 text-center">
-            <label class="checkbox inline-checkbox">Can edit group - added<%= check_box_tag "group_member[edit_users_ids][]", false %></label>
+          <div class="span2 offset1 ">
+            <label class="checkbox inline-checkbox ">Can edit group<%= check_box_tag "group_member[edit_users_ids][]", false %></label>
             <input id="<%=prefix %>_members_attributes_{{index}}_id" name="<%=prefix %>[members_attributes][{{index}}][id]" type="hidden" value="" />
           </div>
         </div>
@@ -40,7 +39,7 @@
       <li class="field-wrapper input-append">
         <div class="row">
           <div class="span7">
-            <span class="linked-user">
+            <span class="linked-user filled-in">
               <a href="/people/{{value}}" target="_new">{{label}}</a>
             </span>
             <input type="hidden" name="<%=prefix %>[members_attributes][{{index}}][id]" value="{{value}}">
@@ -51,8 +50,8 @@
               </button>
             </span>
           </div>
-          <div class="span2 offset1 text-center">
-            <label class="checkbox inline-checkbox">Can edit group - filled out<%= check_box_tag "group_member[edit_users_ids][]", "{{value}}", @group.edit_users.include?("{{value}}") %></label>
+          <div class="span2 offset1 ">
+            <label class="checkbox inline-checkbox">Can edit group<%= check_box_tag "group_member[edit_users_ids][]", "{{value}}", @group.edit_users.include?("{{value}}"), class: "test" %></label>
           </div>
         </div>
       </li>
@@ -80,11 +79,11 @@
                 <span class="field-controls"></span>
               <% end %>
             </div>
-            <div class="span2 offset1 text-center">
-              <label class="checkbox inline-checkbox">Can edit group - normal
+            <div class="span2 offset1 ">
+              <label class="checkbox inline-checkbox">Can edit group
                 <% if memberField.object.persisted? %>
                   <% if ( @group.edit_users.include?(memberField.object.user_key) && ( @group.edit_users.size == 1 ) ) %>
-                    <%= check_box_tag "current_user_disabled", 'checked', true, disabled: true %>
+                    <%= check_box_tag "current_user_disabled ", 'checked', true, disabled: true %>
                     <%= hidden_field_tag "group_member[edit_users_ids][]", memberField.object.pid %>
                   <% else %>
                     <%= check_box_tag "group_member[edit_users_ids][]", memberField.object.id, @group.edit_users.include?(memberField.object.user_key) %>
@@ -98,7 +97,7 @@
         </li>
         <% end %>
       <% end %>
-    </ul>endtest
+    </ul>
   </div>
 </div>
 


### PR DESCRIPTION
closes uclibs/scholar_uc#681

finished up display issues on mobile for the manage groups page.

We need to test it on several devices and browsers.

Minimally on an iPhone and iPad, using chrome and firefox

As well as an android phone and tablet using chrome and firefox

I would do it, however I do not have access to these devices.
