### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 ##########################################################################
-# Copyright 2014 University of Cincinnati
+# Copyright 2016 University of Cincinnati
 # Copyright 2013 University of Notre Dame, Northwestern University, and Data Curation Experts
 # Additional copyright may be held by others, as reflected in the commit history.
 #


### PR DESCRIPTION
Update date to current year. Specifically kept the Notre Dame copyright as 2013 to mirror Hydra Lab's curate license (mentioned in the issue)
