### PR TITLE
Removes the additional details expansion from catalog document view.

### DIFF
--- a/app/views/catalog/_document.html.erb
+++ b/app/views/catalog/_document.html.erb
@@ -14,7 +14,7 @@
     <div class="span10">
       <dl class="attribute-list">
         <% if solr_doc.has?('desc_metadata__creator_tesim') %>
-          <dt>Author(s):</dt>
+          <dt>Creator(s):</dt>
           <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__creator_tesim') %></dd>
         <% end %>
 
@@ -28,21 +28,6 @@
           <dd><%= render_index_field_value(document: solr_doc, field: 'desc_metadata__publisher_tesim') %></dd>
         <% end %>
       </dl>
-
-      <a href="" title="Click for more details"><i id="expand_<%= noid %>" class="icon-plus icon-large show-details"></i></a>
-
-      <dl class="attribute-list extended-attributes hide">
-        <% index_fields.each do |solr_fname, field| -%>
-          <%# NOTE: Attribute display shouldn't come to this %>
-          <% unless ['desc_metadata__contributor_tesim', 'desc_metadata__creator_tesim', 'desc_metadata__description_tesim', 'desc_metadata__publisher_tesim', 'desc_metadata__title_tesim',].include? solr_fname %>
-            <% if should_render_index_field? solr_doc, field %>
-              <dt class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_label field: solr_fname %></dt>
-              <dd class="blacklight-<%= solr_fname.parameterize %>"><%= render_index_field_value document: solr_doc, field: solr_fname %></dd>
-            <% end -%>
-          <% end -%>
-        <% end -%>
-      </dl>
     </div>
-
   </div>
 </li>


### PR DESCRIPTION
Since this behavior was also happening with Generic Work, I made the change to remove the additional details expansion for all work types.

Fixes https://github.com/uclibs/scholar_uc/issues/724.
