### PR TITLE
Add search within collections

### DIFF
--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -21,4 +21,56 @@ module BlacklightHelper
   def field_value_separator
     tag(:br)
   end
+
+  ## Override to return the Collection title when the search is filtered by collection pid
+  include Blacklight::FacetsHelperBehavior
+  def facet_display_value field, item
+    facet_config = facet_configuration_for_field(field)
+
+    value = if item.respond_to? :label
+      value = item.label
+    else
+      facet_value_for_facet_item(item)
+    end
+
+    display_label = case
+      when facet_config.helper_method
+        display_label = send facet_config.helper_method, value
+      when (facet_config.query and facet_config.query[value])
+        display_label = facet_config.query[value][:label]
+      when facet_config.date
+        localization_options = {}
+        localization_options = facet_config.date unless facet_config.date === true
+        display_label = l(value.to_datetime, localization_options)
+      when facet_config.field == "collection_sim"
+        Collection.find(value).title
+      else
+        value
+    end
+  end
+
+  ## Override to insert "Collection" label when serch is filtered by collection pid
+  ## Because this isn't configured as a normal facet, we need to do this
+  include Blacklight::RenderConstraintsHelperBehavior
+  def render_filter_element(facet, values, localized_params)
+    facet_config = facet_configuration_for_field(facet)
+
+    if facet == "collection_sim"
+      values.map do |val|
+        render_constraint_element( "Collection",
+          facet_display_value(facet, val),
+          :remove => url_for(remove_facet_params(facet, val, localized_params)),
+          :classes => ["filter", "filter-" + facet.parameterize]
+        ) + "\n"
+      end
+    else
+      values.map do |val|
+        render_constraint_element( facet_field_labels[facet],
+          facet_display_value(facet, val),
+          :remove => url_for(remove_facet_params(facet, val, localized_params)),
+          :classes => ["filter", "filter-" + facet.parameterize]
+        ) + "\n"
+      end
+    end
+  end
 end

--- a/app/helpers/params_helper.rb
+++ b/app/helpers/params_helper.rb
@@ -9,6 +9,7 @@ module ParamsHelper
 
     unless params["f"].nil?
       safe_params["f"] = Hash.new;
+      safe_params["f"]["collection_sim"] = params["f"]["collection_sim"]
       safe_params["f"]["desc_metadata__creator_sim"] = params["f"]["desc_metadata__creator_sim"]
       safe_params["f"]["desc_metadata__language_sim"] = params["f"]["desc_metadata__language_sim"]
       safe_params["f"]["desc_metadata__publisher_sim"] = params["f"]["desc_metadata__publisher_sim"]
@@ -31,6 +32,7 @@ module ParamsHelper
 
     unless safe_params["f"].nil?
       params["f"] = Hash.new
+      params["f"]["collection_sim"] = safe_params["f"]["collection_sim"] unless safe_params["f"]["collection_sim"].nil?
       params["f"]["desc_metadata__creator_sim"] = safe_params["f"]["desc_metadata__creator_sim"] unless safe_params["f"]["desc_metadata__creator_sim"].nil?
       params["f"]["desc_metadata__language_sim"] = safe_params["f"]["desc_metadata__language_sim"] unless safe_params["f"]["desc_metadata__language_sim"].nil?
       params["f"]["desc_metadata__publisher_sim"] = safe_params["f"]["desc_metadata__publisher_sim"] unless safe_params["f"]["desc_metadata__publisher_sim"].nil?
@@ -40,7 +42,7 @@ module ParamsHelper
       params["per_page"] = safe_params["per_page"] unless safe_params["per_page"].nil?
       params["sort"] = safe_params["sort"] unless safe_params["sort"].nil?
     end
-    
+
     unless safe_params["q"].nil?
       params["q"] = safe_params["q"] unless safe_params["q"].nil?
     end
@@ -174,7 +176,7 @@ module ParamsHelper
   end
 
   def return_404
-    render(:file => File.join(Rails.root, 'public/404.html'), :status => 404) 
+    render(:file => File.join(Rails.root, 'public/404.html'), :status => 404)
   end
 
   private

--- a/app/views/curate/collections/show.html.erb
+++ b/app/views/curate/collections/show.html.erb
@@ -6,6 +6,9 @@
   <% end %>
   <h1> <%= @collection.title %> </h1>
   <p>Collection submitted by: <%= link_owner(@collection).html_safe %></p>
+  <p><%= link_to('Search within this collection',
+           catalog_index_path({"f"=>{"collection_sim"=>[@collection.pid]}}),
+           class: 'btn') %></p>
 <% end %>
 <% if can? :edit, @collection %>
   <% content_for :page_actions do %>

--- a/spec/features/collections_show_spec.rb
+++ b/spec/features/collections_show_spec.rb
@@ -52,5 +52,11 @@ describe "Collections show view: " do
       page.should have_content('Bilbo')
     end
   end
-end
 
+  let(:collection_pid_html) { collection.pid.sub(/:/, '%3A') }
+  let(:search_within_collection_link) { "/catalog?f%5Bcollection_sim%5D%5B%5D=#{collection_pid_html}" }
+  it "shows a link to search within the collection" do
+    visit collection_path(collection.pid)
+    page.body.should have_link("Search within this collection", href: search_within_collection_link)
+  end
+end

--- a/spec/helpers/blacklight_helper_spec.rb
+++ b/spec/helpers/blacklight_helper_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe BlacklightHelper do
+  describe "#facet_display_value" do
+    it "should just be the facet value for an ordinary facet" do
+      helper.stub(:facet_configuration_for_field).with('simple_field').and_return(double(:query => nil, :date => nil, :helper_method => nil, :field => nil))
+      helper.facet_display_value('simple_field', 'asdf').should == 'asdf'
+    end
+
+    it "should allow you to pass in a :helper_method argument to the configuration" do
+      helper.stub(:facet_configuration_for_field).with('helper_field').and_return(double(:query => nil, :date => nil, :helper_method => :my_facet_value_renderer))
+
+      helper.should_receive(:my_facet_value_renderer).with('qwerty').and_return('abc')
+
+      helper.facet_display_value('helper_field', 'qwerty').should == 'abc'
+    end
+
+    it "should extract the configuration label for a query facet" do
+      helper.stub(:facet_configuration_for_field).with('query_facet').and_return(double(:query => { 'query_key' => { :label => 'XYZ'}}, :date => nil, :helper_method => nil))
+      helper.facet_display_value('query_facet', 'query_key').should == 'XYZ'
+    end
+
+    it "should localize the label for date-type facets" do
+      helper.stub(:facet_configuration_for_field).with('date_facet').and_return(double('date' => true, :query => nil, :helper_method => nil))
+      helper.facet_display_value('date_facet', '2012-01-01').should == 'Sun, 01 Jan 2012 00:00:00 +0000'
+    end
+
+    it "should localize the label for date-type facets with the supplied localization options" do
+      helper.stub(:facet_configuration_for_field).with('date_facet').and_return(double('date' => { :format => :short }, :query => nil, :helper_method => nil))
+      helper.facet_display_value('date_facet', '2012-01-01').should == '01 Jan 00:00'
+    end
+
+    it "should look-up a collection title when the field is 'collection_sim'" do
+      helper.stub(:facet_configuration_for_field).with('collection_sim').and_return(double(:query => nil, :date => nil, :helper_method => nil, :field => 'collection_sim'))
+      Collection.stub(:find).with('foo:123').and_return(double(title: 'Test Title'))
+      helper.facet_display_value('collection_sim', 'foo:123').should == 'Test Title'
+    end
+  end
+
+  describe '#render_filter_element' do
+    before do
+      controller.request.path_parameters["controller"] = 'catalog'
+
+      @config = Blacklight::Configuration.new do |config|
+        config.add_facet_field 'type'
+      end
+      helper.stub(:blacklight_config => @config)
+    end
+
+    it "should render the facet field and value" do
+      result = helper.render_filter_element('type', ['journal'], {:q=>'biz'})
+
+      result.size.should == 1
+      # I'm not certain how the ampersand gets in there. It's not important.
+      result.first.should have_content "Type:"
+      result.first.should have_content "journal"
+    end
+
+    it "should render the facet field and value for collections" do
+      Collection.stub(:find).with('foo:123').and_return(double(title: 'Test Title'))
+      result = helper.render_filter_element('collection_sim', ['foo:123'], {:q=>'biz'})
+
+      result.size.should == 1
+      result.first.should have_content "Collection:"
+      result.first.should have_content "Test Title"
+    end
+  end
+end


### PR DESCRIPTION
To implement this I had to modify two blacklight helpers to add special treatment for collections, so it would display the title of the collection instead of the pid in the search constraints partial, and so it would label the constraint with "Collection" (this behavior is only automatic if the field is configured as a facet). To test these, I copied the tests from Blacklight and added additional examples for the behavior I added.

<img width="1256" alt="screen shot 2016-06-16 at 3 31 09 pm" src="https://cloud.githubusercontent.com/assets/2651187/16130497/611ba248-33d7-11e6-9ebe-06c555c8b609.png">

Closes https://github.com/uclibs/scholar_uc/issues/738
