### PR TITLE
Fixes to ETDs

### DIFF
--- a/app/assets/stylesheets/style/theme.css.scss
+++ b/app/assets/stylesheets/style/theme.css.scss
@@ -82,3 +82,12 @@
 .modal-collection {
   position: fixed;
 }
+
+#facets li {
+  margin-right: 0px;
+  padding-right: 0px;
+}
+
+#facets li .count {
+  margin-right: 5px;
+}

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -410,22 +410,12 @@ class CatalogController < ApplicationController
       end
     end
 
-    def hide_managers(solr_parameters, user_parameters)
+		def hide_managers(solr_parameters, user_parameters)
       unless current_user and current_user.manager?
         solr_parameters[:fq] ||= []
         manager_config = "#{::Rails.root}/config/manager_usernames.yml"
         content = IO.read(manager_config)
-        manager_list = YAML.load(ERB.new(content).result).fetch(Rails.env).fetch('manager_usernames')
-
-        if current_user and current_user.etd_manager?
-          list = manager_list
-        else
-          etd_manager_config = "#{::Rails.root}/config/etd_manager_usernames.yml"
-          content = IO.read(etd_manager_config)
-          etd_manager_list = YAML.load(ERB.new(content).result).fetch(Rails.env).fetch('etd_manager_usernames')
-
-          list = etd_manager_list + manager_list
-        end
+        list = YAML.load(ERB.new(content).result).fetch(Rails.env).fetch('manager_usernames')
 
         list.each do |manager|
           solr_parameters[:fq] << "-(+edit_access_person_ssim: #{manager} AND has_model_ssim:\"info:fedora/afmodel:Person\")"

--- a/app/helpers/curate_helper.rb
+++ b/app/helpers/curate_helper.rb
@@ -181,6 +181,7 @@ module CurateHelper
     types = Array.new
     types += Curate.configuration.registered_curation_concern_types
     types.delete("StudentWork")
+    types.delete("Etd")
     types.delete("GenericWork")
     types = (types.sort.collect { |type| type.underscore.humanize.capitalize })
     ## "Generic work" will become "other", so we need to re-add it after the sort is performed

--- a/app/repository_models/etd.rb
+++ b/app/repository_models/etd.rb
@@ -22,7 +22,7 @@ class Etd < ActiveFedora::Base
   self.human_readable_short_description = "Must be submitted by the UC Graduate School"
 
   class_attribute :human_readable_type
-  self.human_readable_type = "ETD"
+  self.human_readable_type = "Thesis or Dissertation"
 
   has_attributes :unit, :unit_attributes, datastream: :descMetadata, multiple: true
 

--- a/app/repository_models/student_work.rb
+++ b/app/repository_models/student_work.rb
@@ -19,7 +19,7 @@ class StudentWork < ActiveFedora::Base
   include CurationConcern::RemotelyIdentifiedByDoi::Attributes
 
   class_attribute :human_readable_short_description
-  self.human_readable_short_description = "Deposit any kind of student work."
+  self.human_readable_short_description = "Deposit any kind of student work (excluding Theses and Dissertations)."
 
   has_attributes :unit, :unit_attributes, datastream: :descMetadata, multiple: true
 

--- a/app/views/classify_concerns/new.html.erb
+++ b/app/views/classify_concerns/new.html.erb
@@ -13,7 +13,11 @@
     <% (order + classify_concern.all_curation_concern_classes).uniq.each do |klass| %>
       <% if can? :create, klass %>
         <li class="work-type">
-          <h3 class="title"><%= klass.human_readable_type %></h3>
+          <% if klass == Etd %>
+            <h3 class="title">ETD</h3>
+          <% else %>
+            <h3 class="title"><%= klass.human_readable_type %></h3>
+          <% end %>
           <p class="short-description"><%= klass.human_readable_short_description %></p>
           <%= link_to 'Add New',
             new_polymorphic_path([:curation_concern, klass]),

--- a/app/views/curation_concern/etds/_attributes.html.erb
+++ b/app/views/curation_concern/etds/_attributes.html.erb
@@ -8,6 +8,7 @@
   <%= curation_concern_attribute_to_html(curation_concern, :advisor, "Advisor") %>
   <%= curation_concern_attribute_to_html(curation_concern, :committee_member, "Other Committee Members") %>
   <%= curation_concern_attribute_to_html(curation_concern, :degree_for_display, "Year and Degree") %>
+  <%= curation_concern_attribute_to_html(curation_concern, :owner, "Submitter") %>
   <%= curation_concern_attribute_to_html(curation_concern, :abstract, "Abstract") %>
   <%= curation_concern_attribute_to_html(curation_concern, :alternate_title, "Alternate Title") %>
   <%= curation_concern_attribute_to_html(curation_concern, :subject, "Subject") %>

--- a/spec/features/etd_spec.rb
+++ b/spec/features/etd_spec.rb
@@ -34,7 +34,7 @@ describe 'Creating an ETD work' do
 
         select(Sufia.config.cc_licenses.keys.first.dup, from: I18n.translate('sufia.field_label.rights'))
         check("I have read and accept the distribution license agreement")
-        click_button("Create ETD")
+        click_button("Create Thesis or Dissertation")
       end
 
       within ('.etd.attributes') do
@@ -59,9 +59,9 @@ describe 'Creating an ETD work' do
           fill_in "External link", with: "http://www.youtube.com/watch?v=oHg5SJYRHA0"
           select(Sufia.config.cc_licenses.keys.first.dup, from: I18n.translate('sufia.field_label.rights'))
           check("I have read and accept the distribution license agreement")
-          click_button("Create ETD")
+          click_button("Create Thesis or Dissertation")
         end
-        expect(page).to have_selector('h1', text: 'ETD')
+        expect(page).to have_selector('h1', text: 'Thesis or Dissertation')
 
         within ('.linked_resource.attributes') do
           expect(page).to have_link('http://www.youtube.com/watch?v=oHg5SJYRHA0', href: 'http://www.youtube.com/watch?v=oHg5SJYRHA0')
@@ -129,7 +129,7 @@ describe 'Viewing an ETD that is private' do
     login_as(user)
     visit curation_concern_etd_path(work)
     page.should have_content('Unauthorized')
-    page.should have_content('The ETD you have tried to access is private')
+    page.should have_content('The Thesis or Dissertation you have tried to access is private')
     page.should have_content("ID: #{work.pid}")
     page.should_not have_content("Sample work")
   end

--- a/spec/features/person_profile_spec.rb
+++ b/spec/features/person_profile_spec.rb
@@ -104,10 +104,6 @@ describe 'Profile for a Person: ' do
     let!(:user) {manager_2.user}
     let!(:person) {manager_2.person}
 
-    let(:etd_manager) {FactoryGirl.create(:account, email: 'etd_manager@example.com', first_name: 'Winston', last_name: 'Churchill')}
-    let!(:user2) {etd_manager.user}
-    let!(:person2) {etd_manager.person}
-
     before do
       login_as(manager_user)
     end
@@ -117,13 +113,6 @@ describe 'Profile for a Person: ' do
       click_button 'keyword-search-submit'
       within('#documents') do
         expect(page).to have_link('Stan Theman') #title
-      end
-
-      visit catalog_index_path
-      fill_in 'Search Curate', with: 'Winston'
-      click_button 'keyword-search-submit'
-      within('#documents') do
-        expect(page).to have_link('Winston Churchill') #title
       end
     end
   end

--- a/spec/helpers/curate_helper_spec.rb
+++ b/spec/helpers/curate_helper_spec.rb
@@ -293,8 +293,8 @@ describe ApplicationHelper do
       expect(helper.work_types_for_student_works).to be_an(Array)
     end
 
-    it 'should contain all the work types except student work' do
-      expect(helper.work_types_for_student_works.length).to eq(types.length - 1)
+    it 'should contain all the work types except student work and Etd' do
+      expect(helper.work_types_for_student_works.length).to eq(types.length - 2)
     end
   end
 end

--- a/spec/views/classify_concerns/new.html.erb_spec.rb
+++ b/spec/views/classify_concerns/new.html.erb_spec.rb
@@ -13,6 +13,16 @@ describe 'classify_concerns/new.html.erb' do
     expect(rendered).to match /Image/
   end
 
+  it 'displays theses and disserations with the ETD label' do
+    classes.each do |klass|
+      allow(view).to receive(:can?).with(:create, klass) { true }
+    end
+    allow(view).to receive(:classify_concern) { stub_model(ClassifyConcern)}
+    render
+    expect(rendered).to match /ETD/
+    expect(rendered).to_not match /Thesis or Dissertation/
+  end
+
   it 'hides curation_concerns without access' do
     (classes - [Image]).each do |klass|
       allow(view).to receive(:can?).with(:create, klass) { true }


### PR DESCRIPTION
This branch:
- restores the ETD Manager profile to the interface (in catalog and as 'Submitter' on work show page) - closes https://github.com/uclibs/scholar_uc/issues/798
- changes 'ETD' to 'Thesis or Dissertation' - closes https://github.com/uclibs/scholar_uc/issues/783
- removes 'Etd' from the worktype dropdown for student works - closes https://github.com/uclibs/scholar_uc/issues/804
- Clarifies the student work description to clarify that ETDs should not be submitted - closes https://github.com/uclibs/scholar_uc/issues/782

It also fusses with the styling on facets to better use available space in the catalog browse.
