### PR TITLE
Feature/#730 speed up collection load

### DIFF
--- a/app/controllers/curate/collections_controller.rb
+++ b/app/controllers/curate/collections_controller.rb
@@ -83,6 +83,9 @@ class Curate::CollectionsController < ApplicationController
 
   def add_member
     if @collection && @collection.add_member(@collectible)
+      item = ActiveFedora::Base.find(params[:collectible_id], cast:true)
+      item.save
+      @collection.save
       flash[:notice] = "\"#{@collectible}\" has been added to \"#{@collection}\""
     else
       flash[:error] = 'Unable to add item to collection.'
@@ -94,6 +97,7 @@ class Curate::CollectionsController < ApplicationController
     @collection = ActiveFedora::Base.find(params[:id], cast: true)
     item = ActiveFedora::Base.find(params[:item_id], cast:true)
     @collection.remove_member(item)
+    ActiveFedora::Base.find(params[:item_id], cast:true).save
     redirect_to params.fetch(:redirect_to) { collection_path(params[:id]) }
   end
 

--- a/app/repository_models/collection.rb
+++ b/app/repository_models/collection.rb
@@ -15,6 +15,14 @@ class Collection < ActiveFedora::Base
 
   before_save :add_profile_image, :only => [ :create, :update ]
 
+  def members_from_solr()
+    Curate.configuration.registered_curation_concern_types.collect do |klass|
+        klass.constantize.send(:find_with_conditions, { collection_sim: self.pid }, { rows: [100], sort: ['sort_title_ssi asc'] }).collect do |result|
+          result
+      end
+    end.flatten
+  end
+
   def can_be_member_of_collection?(collection)
     collection == self ? false : true
   end

--- a/app/repository_models/collection.rb
+++ b/app/repository_models/collection.rb
@@ -15,12 +15,8 @@ class Collection < ActiveFedora::Base
 
   before_save :add_profile_image, :only => [ :create, :update ]
 
-  def members_from_solr()
-    Curate.configuration.registered_curation_concern_types.collect do |klass|
-        klass.constantize.send(:find_with_conditions, { collection_sim: self.pid }, { rows: [100], sort: ['sort_title_ssi asc'] }).collect do |result|
-          result
-      end
-    end.flatten
+  def members_from_solr
+    ActiveFedora::Base.find_with_conditions({ collection_sim: self.pid }, { rows: [2000], sort: ['sort_title_ssi asc'] })
   end
 
   def can_be_member_of_collection?(collection)

--- a/app/repository_models/curation_concern/collection_model.rb
+++ b/app/repository_models/curation_concern/collection_model.rb
@@ -35,6 +35,20 @@ module CurationConcern
     def to_solr(solr_doc={}, opts={})
       super
       Solrizer.set_field(solr_doc, 'generic_type', human_readable_type, :facetable)
+      index_collection_pids(solr_doc)
+      solr_doc
+    end
+
+    def index_collection_pids(solr_doc)
+      solr_doc[Solrizer.solr_name(:collection, :facetable)] ||= []
+      solr_doc[Solrizer.solr_name(:collection)] ||= []
+      self.collection_ids.each do |collection_id|
+        collection_obj = ActiveFedora::Base.load_instance_from_solr(collection_id)
+        if collection_obj.is_a?(Collection)
+          solr_doc[Solrizer.solr_name(:collection, :facetable)] << collection_id
+          solr_doc[Solrizer.solr_name(:collection)] << collection_id
+        end
+      end
       solr_doc
     end
 

--- a/app/views/curate/collections/show.html.erb
+++ b/app/views/curate/collections/show.html.erb
@@ -5,7 +5,7 @@
     <%= render :partial => 'curate/collections/thumbnail_display', locals: {document: @collection} %>
   <% end %>
   <h1> <%= @collection.title %> </h1>
-  <p>Collection submitted by: <%= link_owner(@collection).html_safe %></p>
+  <p>Collection submitted by: <%= link_owner.html_safe %></p>
   <p><%= link_to('Search within this collection',
            catalog_index_path({"f"=>{"collection_sim"=>[@collection.pid]}}),
            class: 'btn') %></p>

--- a/spec/repository_models/curation_concern/collection_model_spec.rb
+++ b/spec/repository_models/curation_concern/collection_model_spec.rb
@@ -52,4 +52,25 @@ describe CurationConcern::CollectionModel do
       expect(collection.sortable_title).to eq("title")
     end
   end
+
+  describe '#members_from_solr' do
+    collection = FactoryGirl.create(:collection, title: "A title")
+    collection2 = FactoryGirl.create(:collection, title: "A subcollection")
+    article = FactoryGirl.create(:article, title: "test collection article")
+    collection.add_member(article)
+
+    it 'returns array of hashes from solr of collection members' do
+      expect(collection.members_from_solr.first["desc_metadata__title_tesim"]).to eq(["test collection article"])
+    end
+
+    it 'returns subcollections' do
+      collection.add_member(collection2)
+      expect(collection.members_from_solr.last["active_fedora_model_ssi"]).to eq("Collection")
+    end
+
+    it 'returns the same member count as fedora' do
+      expect(collection.members.length).to eq(collection.members_from_solr.length)
+    end
+  end
+
 end

--- a/spec/views/curate/collections/show.html.erb_spec.rb
+++ b/spec/views/curate/collections/show.html.erb_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe 'curate/collections/show.html.erb' do
-  let(:parent_collection) { FactoryGirl.build(:collection, title: "Top Level Collection") }
-  let(:child_collection) { FactoryGirl.build(:collection, title: "Inner Level Collection") }
+  let(:parent_collection) { FactoryGirl.create(:collection, title: "Top Level Collection") }
+  let(:child_collection) { FactoryGirl.create(:collection, title: "Inner Level Collection") }
 
   it "displays the parent/child relationship between nested collections" do
     parent_collection.add_member(child_collection)


### PR DESCRIPTION
Closes https://github.com/uclibs/scholar_uc/issues/730

This is in two commits, one from @crowesn and the other from me.

We decided that profiles were out of scope, so the general strategy was to determine whether the object was a Profile or a Collection (see `#list_items_in_collection` in the `CollectionHelper), and if it's a Collection, we're using separate methods suffixed with`_solr`to convert the Solr output into an`OpenStruct` and handle it appropriately for the show page. Because of this approach, no additional tests were needed for the show page (because the page is still the same).

To make this possible, we had make a few other changes, which are tested:
- Indexing collections, when a collection is a member of a collection
- The `members_from_solr` method on the collection model
- Resaving objects when adding members, to ensure solr updates (this might not be tested - lemme know if you think it should be)
