### PR TITLE
prevent collection icon from displaying if you can't collect the object

### DIFF
--- a/app/views/catalog/_index_partials/_identifier_and_action.html.erb
+++ b/app/views/catalog/_index_partials/_identifier_and_action.html.erb
@@ -38,7 +38,9 @@
 
       <% unless document.respond_to?(:user) %>
         <% if can? :collect, document %>
-          <%= render 'add_to_collection_gui', collectible: document %>
+          <% if document.edit_users.include?(current_user.email) %>
+            <%= render 'add_to_collection_gui', collectible: document %>
+          <% end %>
         <% end %>
       <% end %>
     <% end %>

--- a/app/views/curation_concern/base/show.html.erb
+++ b/app/views/curation_concern/base/show.html.erb
@@ -27,8 +27,10 @@
         <%= link_to "Attach a File", new_curation_concern_generic_file_path(curation_concern), class: 'btn btn-primary' %>
         <%= link_to "Add an External Link", new_curation_concern_linked_resource_path(curation_concern), class: 'btn btn-primary' %>
       <% end %>
-      <% if collector %>
-        <%= render 'add_to_collection_gui', collectible: curation_concern, button_class: 'btn btn-primary' %>
+      <% unless current_user.nil? %>
+        <% if collector && curation_concern.edit_users.include?(current_user.email) %>
+          <%= render 'add_to_collection_gui', collectible: curation_concern, button_class: 'btn btn-primary' %>
+        <% end %>
       <% end %>
     </div>
   </div>

--- a/spec/features/catalog_spec.rb
+++ b/spec/features/catalog_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+describe 'the collection icon' do
+  let(:person) { FactoryGirl.create(:person_with_user) }
+  let(:user) { person.user }
+  let(:other_person) { FactoryGirl.create(:person_with_user) }
+  let(:other_user) { other_person.user }
+  let!(:generic_work) { FactoryGirl.create(:generic_work, user: user) }
+ 
+  after do
+    logout
+  end
+ 
+  context 'in the catalog' do
+    context 'with a logged in user' do
+      it 'should be displayed if the work is owned by that user' do
+        login_as(user)
+        visit root_path
+        body.should include(generic_work.noid + '-modal')
+      end
+ 
+      it 'should not be displayed if the work is not owned by that user' do
+        login_as(other_user)
+        visit root_path
+        body.should_not include(generic_work.noid + '-modal')
+      end
+    end
+  end
+
+  context 'in the work show view' do
+    context 'with a logged in user' do
+      it 'should be displayed if the work is owned by that user' do
+        login_as(user)
+        visit curation_concern_generic_work_path generic_work.noid
+        body.should include(generic_work.noid + '-modal')
+      end
+
+      it 'should not be displayed if the work is not owned by that user' do
+        login_as(other_user)
+        visit curation_concern_generic_work_path generic_work.noid
+        body.should_not include(generic_work.noid + '-modal')
+      end
+    end
+  end
+end


### PR DESCRIPTION
closes uclibs/scholar_uc#810

note: this is using the same method as in https://github.com/uclibs/curate/blob/develop/app/views/curate/collections/_form_to_add_member.html.erb#L19 so if there are no profile sections in the modal you have access to, you will not see the icon. As far as I understand this was the reason behind the issue and solves it concisely without any further lookups to fedora.
