### PR TITLE
Toggle virus scanning by adding/removing the clamav gem in the app

### DIFF
--- a/app/controllers/curation_concern/generic_files_controller.rb
+++ b/app/controllers/curation_concern/generic_files_controller.rb
@@ -11,7 +11,9 @@ class CurationConcern::GenericFilesController < CurationConcern::BaseController
   before_filter :parent
   before_filter :cloud_resources_valid?, only: :create
   before_filter :authorize_edit_parent_rights!, except: [:show]
-  before_filter :scan_viral_files, only: [:create, :update]
+  if defined?(ClamAV)
+    before_filter :scan_viral_files, only: [:create, :update]
+  end
 
   def scan_viral_files
     good_files = []
@@ -65,7 +67,7 @@ class CurationConcern::GenericFilesController < CurationConcern::BaseController
 
   def create
     curation_concern.batch = parent
-    if attributes_for_actor["file"] || attributes_for_actor["cloud_resources"] 
+    if attributes_for_actor["file"] || attributes_for_actor["cloud_resources"]
       if actor.create
         curation_concern.update_parent_representative_if_empty(parent)
         respond_with([:curation_concern, parent])

--- a/app/controllers/curation_concern/generic_works_controller.rb
+++ b/app/controllers/curation_concern/generic_works_controller.rb
@@ -1,7 +1,9 @@
 class CurationConcern::GenericWorksController < CurationConcern::BaseController
   respond_to(:html)
   with_themed_layout '1_column'
-  before_filter :remove_viral_files, only: [:create]
+  if defined?(ClamAV)
+    before_filter :remove_viral_files, only: [:create]
+  end
 
   def remove_viral_files
     viral_files = []

--- a/lib/generators/curate/curate_generator.rb
+++ b/lib/generators/curate/curate_generator.rb
@@ -117,7 +117,7 @@ This generator makes the following changes to your application:
   end
 
   def create_clamav_initializer
-    create_file('config/initializers/clamav.rb', "ClamAV.instance.loaddb()")
+    create_file('config/initializers/clamav.rb', "ClamAV.instance.loaddb() if defined? ClamAV")
   end
 
   def create_recipients_list

--- a/spec/support/clamav.rb
+++ b/spec/support/clamav.rb
@@ -1,0 +1,15 @@
+# Mock ClamAV behavior when ClamAV is turned off
+if defined?(ClamAV)
+  ClamAV.instance.loaddb
+else
+  class ClamAV
+    include Singleton
+    def scanfile(_f)
+      0
+    end
+
+    def loaddb
+      nil
+    end
+  end
+end

--- a/tasks/curate_tasks.rake
+++ b/tasks/curate_tasks.rake
@@ -43,7 +43,7 @@ task :generate do
     gem 'curate', :path=>'../../../#{File.expand_path('../../', __FILE__).split('/').last}'
     gem 'kaminari', github: 'harai/kaminari', branch: 'route_prefix_prototype'
     gem 'browse-everything'
-    gem 'clamav'
+#    gem 'clamav'
     gem 'resque'
     gem 'resque-scheduler'
     gem 'change_manager'


### PR DESCRIPTION
This removes the clamav gem from the test app by default.  Curate will only scan for viruses when the gem is added to the test app's gemfile.  So we can run the test app in our dev environments without having to build the clamav gem.  Travis will also run without having to load virus definitions.  

Once this is merged I will open a PR on scholar_uc to remove the clamav gem and point to this updated Curate.  We will only include the clamav gem in our server environments.


To test this:

1. Download a file that that contains a virus test string (found here: https://www.eicar.org/download/eicar.com.txt)
1. Regenerate the test app
1. Log in and create a work with the virus text file attached.  Curate should allow the virus file to be uploaded because virus scanning is disabled.
1. Quit the test app
1. Enable virus scanning by uncommenting the clamav gem in the test app's Gemfile and save
1. bundle install (in the test app)
1. start the test app
1. Log in and create a work with the virus text file attached.  Curate should flash a message that the file contains a virus.

