### PR TITLE
Monkey patch handle control chars in form input

### DIFF
--- a/config/initializers/rsolr_sanitize_monkey_patch.rb
+++ b/config/initializers/rsolr_sanitize_monkey_patch.rb
@@ -1,0 +1,53 @@
+#frozen_string_literal: true
+require 'rsolr/client'
+
+# Monkey patch to sanitize form input to remove control characters before solr indexing.
+
+module RSolr
+  class Client
+    add_instance_method = instance_method(:add)
+    define_method(:add) do |doc, *args|
+      sanitized_document = SanitizeControlCharactersForIndexing.sanitize_document(doc)
+      add_instance_method.bind(self).call(sanitized_document, *args)
+    end
+  end
+end
+
+# Responsible for exposing a sanitization method for control characters when indexing Solr.
+#
+# Without these changes we end up with an exception of the following form:
+#
+# ```ruby
+#   RSolr::Error::Http - 400 Bad Request
+#   Error: {'responseHeader'=>{'status'=>400,'QTime'=>31},'error'=>{'msg'=>'Illegal character ((CTRL-CHAR, code 12))
+#     at [row,col {unknown-source}]: [1,70]','code'=>400}}
+# ```
+module SanitizeControlCharactersForIndexing
+  def self.sanitize_document(doc)
+    sanitized_doc = {}
+    doc.each_pair do |key, value|
+      sanitized_doc[key] = sanitize_value(value)
+    end
+    sanitized_doc
+  end
+
+  def self.sanitize_value(value) # rubocop:disable Metrics/MethodLength
+    case value
+    when Hash
+      sanitize_document(value)
+    when Array
+      value.map { |v| sanitize_value(v) }
+    when String
+      value.gsub(/[[:cntrl:]]/) do |character|
+        case character
+        when "\t", "\n", "\r"
+          character
+        else
+          " "
+        end
+      end
+    else
+      value
+    end
+  end
+end

--- a/spec/initializers/sanitize_control_characters_for_indexing_spec.rb
+++ b/spec/initializers/sanitize_control_characters_for_indexing_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require 'spec_helper'
+
+describe SanitizeControlCharactersForIndexing do
+  it 'will escape control characters on solrize' do
+    expect { ActiveFedora::SolrService.add(title_tesim: "a\fb\tc", id: '123') }.not_to raise_error
+  end
+
+  context '.sanitize_document' do
+    it "preserves tabs, newline, and form feed control characters but replaces others with a blank" do
+      expect(described_class.sanitize_document(hello: "w\n\foot")).to eq(hello: "w\n oot")
+    end
+  end
+
+  context '.sanitize_value' do
+    it "preserves tabs, newline, and form feed control characters but replaces others with a blank" do
+      given = "a\tb\nc\fd\re"
+      expected = "a\tb\nc d\re"
+      expect(described_class.sanitize_value(given)).to eq(expected)
+    end
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/uclibs/scholar_uc/issues/1010 

Rsolr version in Sufia defaults to xml serialization, making control chars illegal and crashing the app when they are included in form input. A patch has been added to Rsolr upstream (defaulting to json serialization). In the meantime, we can monkey patch rsolr to filter out control chars before indexing in solr.

Changes proposed in this pull request:
* Add Rsolr monkey patch with method to sanitize input before solr index.
* Add specs to test the sanitize methods.

Related https://github.com/uclibs/scholar_uc/issues/1022